### PR TITLE
fix: Include new podspec location in packages.json for distribution

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
   "files": [
     "android/",
     "ios/",
-    "index.d.ts"
+    "index.d.ts",
+    "SRSRadialGradient.podspec"
   ],
   "types": "index.d.ts",
   "keywords": [


### PR DESCRIPTION
This commit moved the podspec to root, breaking a bunch of Podfiles in the wild, but then also didn't include the podspec in the files array, so no distributions have it anymore. This breaks all 1.1.5 deployments. https://github.com/surajitsarkar19/react-native-radial-gradient/commit/c809beec4bbf35666906c89857c7d57f0e206bc1

This PR attempts to include the new location of the podspec in the distribution. Recommend bumping to 1.1.6 and releasing.